### PR TITLE
Support wildcard stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,4 @@ api = "0.8"
   pre-package = "./scripts/build.sh"
 
 [[stacks]]
-  id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-  id = "io.paketo.stacks.tiny"
+  id = "*"

--- a/integration.json
+++ b/integration.json
@@ -1,4 +1,4 @@
 {
-  "builders" : ["paketobuildpacks/builder:buildpackless-base", "paketobuildpacks/builder-jammy-buildpackless-base"],
+  "builders" : ["paketobuildpacks/builder:buildpackless-base", "paketobuildpacks/builder-jammy-buildpackless-tiny"],
   "dep": "github.com/paketo-buildpacks/dep"
 }

--- a/integration.json
+++ b/integration.json
@@ -1,4 +1,4 @@
 {
-  "builders" : ["paketobuildpacks/builder:buildpackless-base", "paketobuildpacks/builder-jammy-buildpackless-tiny"],
+  "builders" : ["paketobuildpacks/builder:buildpackless-base",  "paketobuildpacks/builder-jammy-buildpackless-base"],
   "dep": "github.com/paketo-buildpacks/dep"
 }

--- a/integration.json
+++ b/integration.json
@@ -1,3 +1,4 @@
 {
+  "builders" : ["paketobuildpacks/builder:buildpackless-base", "paketobuildpacks/builder-jammy-buildpackless-base"],
   "dep": "github.com/paketo-buildpacks/dep"
 }

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -48,43 +48,49 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
-		it("builds successfully", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "default"))
-			Expect(err).NotTo(HaveOccurred())
+		for _, b := range settings.Config.Builders {
+			builder := b
+			context(fmt.Sprintf("with %s", builder), func() {
+				it("builds successfully", func() {
+					var err error
+					source, err = occam.Source(filepath.Join("testdata", "default"))
+					Expect(err).NotTo(HaveOccurred())
 
-			var logs fmt.Stringer
-			image, logs, err = pack.Build.
-				WithPullPolicy("never").
-				WithBuildpacks(
-					settings.Buildpacks.Dep.Online,
-					settings.Buildpacks.DepEnsure.Online,
-				).
-				Execute(name, source)
-			Expect(err).ToNot(HaveOccurred(), logs.String)
+					var logs fmt.Stringer
+					image, logs, err = pack.Build.
+						WithPullPolicy("never").
+						WithBuildpacks(
+							settings.Buildpacks.Dep.Online,
+							settings.Buildpacks.DepEnsure.Online,
+						).
+						WithBuilder(builder).
+						Execute(name, source)
+					Expect(err).ToNot(HaveOccurred(), logs.String)
 
-			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
-				"  Executing build process",
-				"    Running 'dep ensure'",
-				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
-			))
+					Expect(logs).To(ContainLines(
+						MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+						"  Executing build process",
+						"    Running 'dep ensure'",
+						MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+					))
 
-			container, err = docker.Container.Run.
-				WithCommand("ls -alR /workspace").
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
+					container, err = docker.Container.Run.
+						WithCommand("ls -alR /workspace").
+						Execute(image.ID)
+					Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() string {
-				cLogs, err := docker.Container.Logs.Execute(container.ID)
-				Expect(err).NotTo(HaveOccurred())
-				return cLogs.String()
-			}).Should(
-				And(
-					ContainSubstring("Gopkg.lock"),
-					ContainSubstring("vendor/github.com/ZiCog/shiny-thing"),
-				),
-			)
-		})
+					Eventually(func() string {
+						cLogs, err := docker.Container.Logs.Execute(container.ID)
+						Expect(err).NotTo(HaveOccurred())
+						return cLogs.String()
+					}).Should(
+						And(
+							ContainSubstring("Gopkg.lock"),
+							ContainSubstring("vendor/github.com/ZiCog/shiny-thing"),
+						),
+					)
+				})
+			})
+		}
 	})
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -30,7 +30,8 @@ var settings struct {
 		Name string
 	}
 	Config struct {
-		Dep string `json:"dep"`
+		Dep      string   `json:"dep"`
+		Builders []string `json:"builders"`
 	}
 }
 

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -77,38 +77,46 @@ function tools::install() {
 }
 
 function images::pull() {
-  local builder
-  builder=""
+  local builders
+  builders=""
 
   if [[ -f "${BUILDPACKDIR}/integration.json" ]]; then
-    builder="$(jq -r .builder "${BUILDPACKDIR}/integration.json")"
+    builders="$(jq -r .builder "${BUILDPACKDIR}/integration.json")"
+
+    if [[ "${builders}" == "null" || -z "${builders}" ]]; then
+      builders="$(jq -r 'select(.builders != null) | .builders[]' "${BUILDPACKDIR}/integration.json")"
+    fi
   fi
 
-  if [[ "${builder}" == "null" || -z "${builder}" ]]; then
-    builder="index.docker.io/paketobuildpacks/builder:buildpackless-base"
+  if [[ "${builders}" == "null" || -z "${builders}" ]]; then
+    builders="index.docker.io/paketobuildpacks/builder:buildpackless-base"
   fi
 
-  util::print::title "Pulling builder image..."
-  docker pull "${builder}"
+  while read -r builder; do
+    util::print::title "Pulling builder image ${builder}..."
+    docker pull "${builder}"
+
+    local run_image lifecycle_image
+    run_image="$(
+      pack inspect-builder "${builder}" --output json \
+        | jq -r '.remote_info.run_images[0].name'
+    )"
+    lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
+      pack inspect-builder "${builder}" --output json \
+        | jq -r '.remote_info.lifecycle.version'
+    )"
+
+    util::print::title "Pulling run image..."
+    docker pull "${run_image}"
+
+    util::print::title "Pulling lifecycle image..."
+    docker pull "${lifecycle_image}"
+  done <<< "${builders}"
 
   util::print::title "Setting default pack builder image..."
-  pack config default-builder "${builder}"
-
-  local run_image lifecycle_image
-  run_image="$(
-    pack inspect-builder "${builder}" --output json \
-      | jq -r '.remote_info.run_images[0].name'
-  )"
-  lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
-    pack inspect-builder "${builder}" --output json \
-      | jq -r '.remote_info.lifecycle.version'
-  )"
-
-  util::print::title "Pulling run image..."
-  docker pull "${run_image}"
-
-  util::print::title "Pulling lifecycle image..."
-  docker pull "${lifecycle_image}"
+  local default
+  read -r default <<< "${builders}"
+  pack config default-builder "${default}"
 }
 
 function token::fetch() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Since `dep ensure` just depends on the presence of `dep`, I figured it'd be reasonable to make this buildpack support the wildcard stack. This is in keeping with the Paketo Style Guide comments on using the most permissive stack that's reasonable.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This will allow the Go language family buildpack to run on Jammy Jellyfish stacks.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
