### PR TITLE
Add buildpack deprecation warning

### DIFF
--- a/build.go
+++ b/build.go
@@ -23,6 +23,9 @@ func Build(
 
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
+		logger.Process("WARNING: This buildpack is deprecated. It will be removed within 30 days. See https://github.com/paketo-buildpacks/go/issues/622.")
+		logger.Break()
+
 		logger.Process("Executing build process")
 
 		depcachedirLayer, err := context.Layers.Get("depcachedir")

--- a/build_test.go
+++ b/build_test.go
@@ -22,14 +22,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		layersDir    string
-		workingDir   string
-		cnbDir       string
+		build        packit.BuildFunc
 		buildProcess *fakes.BuildProcess
+		clock        chronos.Clock
+		cnbDir       string
+		layersDir    string
 		logs         *bytes.Buffer
 		timeStamp    time.Time
-		clock        chronos.Clock
-		build        packit.BuildFunc
+		workingDir   string
 	)
 
 	it.Before(func() {
@@ -96,6 +96,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(buildProcess.ExecuteCall.Receives.Workspace).To(Equal(workingDir))
 		Expect(buildProcess.ExecuteCall.Returns.Err).To(BeNil())
 		Expect(logs.String()).To(ContainSubstring("Some Buildpack some-version"))
+		Expect(logs.String()).To(ContainSubstring("WARNING: This buildpack is deprecated. It will be removed within 30 days. See https://github.com/paketo-buildpacks/go/issues/622."))
 		Expect(logs.String()).To(ContainSubstring("Executing build process"))
 		Expect(logs.String()).To(ContainSubstring("Completed in "))
 	})

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -69,6 +69,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 
 					Expect(logs).To(ContainLines(
 						MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+						"  WARNING: This buildpack is deprecated. It will be removed within 30 days. See https://github.com/paketo-buildpacks/go/issues/622.",
+						"",
 						"  Executing build process",
 						"    Running 'dep ensure'",
 						MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Per https://github.com/paketo-buildpacks/go/issues/622, adds a warning that this buildpack will be removed in 30 days.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
