### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -4,7 +4,7 @@ api = "0.7"
   description = "A buildpack for installing Go modules using dep"
   homepage = "https://github.com/paketo-buildpacks/dep-ensure"
   id = "paketo-buildpacks/dep-ensure"
-  name = "Paketo Dep Ensure Buildpack"
+  name = "Paketo Buildpack for Dep Ensure"
   keywords = ["go", "dep", "ensure", "modules"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Dep Ensure Buildpack' to 'Paketo Buildpack for Dep Ensure'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
