### PR TITLE
Removes deprecation warning

### DIFF
--- a/build.go
+++ b/build.go
@@ -23,7 +23,6 @@ func Build(
 
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
-		logger.Process("WARNING: This buildpack is deprecated. It will be removed within 30 days. See https://github.com/paketo-buildpacks/go/issues/622.")
 		logger.Break()
 
 		logger.Process("Executing build process")

--- a/build_test.go
+++ b/build_test.go
@@ -96,7 +96,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(buildProcess.ExecuteCall.Receives.Workspace).To(Equal(workingDir))
 		Expect(buildProcess.ExecuteCall.Returns.Err).To(BeNil())
 		Expect(logs.String()).To(ContainSubstring("Some Buildpack some-version"))
-		Expect(logs.String()).To(ContainSubstring("WARNING: This buildpack is deprecated. It will be removed within 30 days. See https://github.com/paketo-buildpacks/go/issues/622."))
 		Expect(logs.String()).To(ContainSubstring("Executing build process"))
 		Expect(logs.String()).To(ContainSubstring("Completed in "))
 	})

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -65,7 +65,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
-				"  WARNING: This buildpack is deprecated. It will be removed within 30 days. See https://github.com/paketo-buildpacks/go/issues/622.",
 				"",
 				"  Executing build process",
 				"    Running 'dep ensure'",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Removes the deprecation warning so that it can continue to be used outside the Paketo project without a scary log line.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Other projects may use and deprecate this buildpack on their own timeline and so this log line doesn't apply to them.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
